### PR TITLE
Add websocket logic for login to lobby and matchmaking

### DIFF
--- a/backend/src/matchmaking/matchmaking_handler.py
+++ b/backend/src/matchmaking/matchmaking_handler.py
@@ -3,69 +3,97 @@ import json
 import websockets
 import random
 import string
+import time
 
-# List to keep track of connected clients
-clients = []
+# Dictionary to track rooms and their clients, along with expiration time and client ID
+clients = {}
 match_code = None
+EXPIRATION_TIME = 300  # 5 minutes for match code to expire (in seconds)
 
 # Function to generate a random matchmaking code
 def generate_match_code(length=6):
     characters = string.ascii_letters + string.digits  # Alphanumeric characters
     return ''.join(random.choice(characters) for _ in range(length))
 
+# Function to generate a random client ID
+def generate_client_id():
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+
 # WebSocket handler for matchmaking
 async def handle_websocket_ping(websocket, path):
     global match_code
-    # Add new client to the list
-    clients.append(websocket)
-    client_id = clients.index(websocket) + 1
-    print(f"Client {client_id} connected")
+    client_id = generate_client_id()  # Assign a unique ID to the client
+    print(f"New connection established, Client ID: {client_id}")
 
     try:
-        if len(clients) == 1:
-            # First client connected, generate match code
-            match_code = generate_match_code()
-            message = json.dumps({"message": "Match code", "code": match_code})
-            await websocket.send(message)
-            print(f"Generated match code: {match_code}")
-
-        elif len(clients) == 2:
-            # Second client connected, validate match code
-            await websocket.send(f"Join with match code: {match_code}")
-            print("Second client connected. Ready for match.")
-
-            # Start matchmaking server logic
-            await start_matchmaking_server()
-
-        else:
-            # More than 2 clients trying to connect
-            await websocket.send("Match full, try again later.")
-            clients.remove(websocket)
-            return
-
         # Keep connection alive, wait for messages
         async for message in websocket:
-            print(f"Received message from client {client_id}: {message}")
+            print(f"Received message from Client ID {client_id}: {message}")
+            data = json.loads(message)
+
+            # Handle room creation request (Player A)
+            if data.get("action") == "create":
+                # Generate match code and set expiration time
+                match_code = generate_match_code()
+                expiration_time = time.time() + EXPIRATION_TIME
+                clients[match_code] = {"connections": [(websocket, client_id)], "expiration": expiration_time}
+                response = {"action": "create", "message": "Match code generated", "code": match_code}
+                await websocket.send(json.dumps(response))
+                print(f"Generated match code {match_code} for Client ID {client_id}")
+
+            # Handle join request (Player B)
+            elif data.get("action") == "join" and data.get("code"):
+                room_code = data["code"]
+                current_time = time.time()
+                if room_code in clients:
+                    room = clients[room_code]
+                    # Check if the match code is still valid
+                    if room["expiration"] < current_time:
+                        # Match code expired
+                        response = {"status": "error", "message": "Match code expired"}
+                        await websocket.send(json.dumps(response))
+                        del clients[room_code]
+                        print(f"Match code {room_code} expired for Client ID {client_id}")
+                    # Check if room is full (already 2 players)
+                    elif len(room["connections"]) >= 2:
+                        response = {"status": "error", "message": "Room is full"}
+                        await websocket.send(json.dumps(response))
+                        print(f"Client ID {client_id} tried to join a full room with code {room_code}")
+                    else:
+                        # Add Player B to the room
+                        room["connections"].append((websocket, client_id))
+                        response = {"status": "success", "message": "Joined the room"}
+                        await websocket.send(json.dumps(response))
+                        # Notify Player A that Player B has joined
+                        await room["connections"][0][0].send(json.dumps({"status": "success", "message": "Opponent has joined"}))
+                        await start_matchmaking_server(room_code)
+                        print(f"Client ID {client_id} joined room with code {room_code}")
+                else:
+                    # Invalid code, reject connection
+                    response = {"status": "error", "message": "Invalid access code"}
+                    await websocket.send(json.dumps(response))
+                    print(f"Client ID {client_id} entered an invalid code {room_code}")
 
     except websockets.ConnectionClosed:
-        print(f"Client {client_id} disconnected")
+        print(f"Client ID {client_id} disconnected")
     finally:
-        # Remove client from the list on disconnection
-        if websocket in clients:
-            clients.remove(websocket)
-            reassign_client_ids()
+        # Clean up: Remove client on disconnect if part of a room
+        for room_code, room in clients.items():
+            for connection, conn_id in room["connections"]:
+                if websocket == connection:
+                    room["connections"].remove((connection, conn_id))
+                    if len(room["connections"]) == 0:
+                        del clients[room_code]
+                    print(f"Client ID {client_id} disconnected from room {room_code}")
+                    break
 
 # Function to start the matchmaking server
-async def start_matchmaking_server():
-    print("Matchmaking process started")
-    # You can place your logic here for starting the game or assigning teams.
-    if len(clients) == 2:
-        # Notify both clients that the match is starting
-        await clients[0].send("Match has started!")
-        await clients[1].send("Match has started!")
-        print("Both clients have been notified that the match has started.")
-
-# Function to reassign client IDs after a disconnection
-def reassign_client_ids():
-    for i, client in enumerate(clients):
-        print(f"Reassigning client {i + 1}")
+async def start_matchmaking_server(room_code):
+    print(f"Matchmaking process started for room {room_code}")
+    # Notify both clients that the match is starting
+    if len(clients[room_code]["connections"]) == 2:
+        client1_id = clients[room_code]["connections"][0][1]
+        client2_id = clients[room_code]["connections"][1][1]
+        await clients[room_code]["connections"][0][0].send(json.dumps({"action": "start", "message": "Match has started!"}))
+        await clients[room_code]["connections"][1][0].send(json.dumps({"action": "start", "message": "Match has started!"}))
+        print(f"Both clients in room {room_code} (Client IDs {client1_id} and {client2_id}) have been notified that the match has started.")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,9 +6,11 @@ import WebSocket from './components/WebSocket';
 import Matchmaking from './components/Matchmaking';
 import Login from './components/Login';
 import Lobby from './components/Lobby';
+import { WebSocketProvider } from './contexts/WebSocketContext';
 
 const App: React.FC = () => {
   return (
+    <WebSocketProvider>
     <Router>
       <Routes>
         <Route path="/matchmaking" Component={Matchmaking} />
@@ -17,6 +19,7 @@ const App: React.FC = () => {
         <Route path="/" Component={WebSocket} />
       </Routes>
     </Router>
+    </WebSocketProvider>
   );
 };
 

--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -1,40 +1,72 @@
 // src/pages/RoomSelection.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/Login.css';
+import { useWebSocket } from '../contexts/WebSocketContext';
 
 const Lobby: React.FC = () => {
-  const [inviteCode, setInviteCode] = useState<string>('');
+  const [inviteCode, setInviteCode] = useState<string>(''); // State to hold access code
+  const [errorMessage, setErrorMessage] = useState<string>(''); // State to handle errors
+  const socket = useWebSocket(); // Access WebSocket from context
   const navigate = useNavigate();
 
-  const handleCreateRoom = () => {
-    navigate('/matchmaking'); // Player A creates a room and goes to matchmaking
-  };
+  useEffect(() => {
+    if (socket) {
+      socket.onopen = () => {
+        console.log('Connected to WebSocket');
+      };
+
+      socket.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        if (data.status === 'success') {
+          // Navigate to the match page on successful room join
+          navigate('/match');
+        } else if (data.status === 'error') {
+          setErrorMessage(data.message); // Display error message on invalid code
+        }
+      };
+    }
+
+    return () => {
+      // Clean up WebSocket connection when the component unmounts
+      if (socket) {
+        socket.onmessage = null
+      }
+    };
+  }, [socket, navigate]);
 
   const handleJoinRoom = () => {
-    if (inviteCode.trim()) {
-      // Pass the invite code to matchmaking to join the same room
-      navigate(`/matchmaking/${inviteCode}`);
+    if (socket && inviteCode.trim()) {
+      // Send the access code to the WebSocket for validation
+      const message = JSON.stringify({
+        action: 'join',
+        code: inviteCode.trim(),
+      });
+      socket.send(message);
     }
   };
+
+  const handleCreateRoom = () => {
+    navigate("/matchmaking")
+  }
 
   return (
     <div className="container">
       <div className="white-box">
         <h1>Lobby</h1>
         <div className="panel-container">
-        <div className="panel">
-          <button className="accent-button" onClick={handleCreateRoom}>Create Room</button>
-        </div>
-        <div className="panel">
-          <input
-            type="text"
-            value={inviteCode}
-            onChange={(e) => setInviteCode(e.target.value)}
-            placeholder="Enter invite code"
-          />
-          <button className="accent-button" onClick={handleJoinRoom}>Join Room</button>
-        </div>
+          <div className="panel">
+            <button className="accent-button" onClick={handleCreateRoom}>Create Room</button>
+          </div>
+          <div className="panel">
+            <input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="Enter invite code"
+            />
+            <button className="accent-button" onClick={handleJoinRoom}>Join Room</button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/contexts/WebSocketContext.tsx
+++ b/frontend/src/contexts/WebSocketContext.tsx
@@ -1,0 +1,34 @@
+// src/contexts/WebSocketContext.tsx
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+// Create a context for WebSocket
+const WebSocketContext = createContext<WebSocket | null>(null);
+
+interface WebSocketProviderProps {
+  children: ReactNode; // Define children as ReactNode
+}
+
+export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }) => {
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:8000');
+    ws.onopen = () => {
+      console.log('Connected to WebSocket');
+      setSocket(ws);
+    };
+
+    return () => {
+      // Cleanup WebSocket connection
+      ws.close();
+    };
+  }, []);
+
+  return (
+    <WebSocketContext.Provider value={socket}>
+      {children} {/* Render children inside the provider */}
+    </WebSocketContext.Provider>
+  );
+};
+
+export const useWebSocket = () => useContext(WebSocketContext);


### PR DESCRIPTION
- Changed `websocket_handler.py` to use client_id and other info instead of using client number to track number of connections in a room
- Added `WebsocketContext` so that websocket shares the same instance between pages
- Added logic to prevent 3rd person using the same code to join the lobby and code has expiration
- When player B enters the invite code, both player A and B should navigate to the next page